### PR TITLE
expose Token, Value and Pos on LexToken

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -330,6 +330,21 @@ func (lt *LexToken) String() string {
 	return fmt.Sprintf("%q (%d) = %T{%v} %d:%d", name, lt.token, lt.value, lt.value, lt.pos.Lineno, lt.pos.ColOffset)
 }
 
+// Token returns the int value of this token
+func (lt *LexToken) Token() int {
+	return lt.token
+}
+
+// Value returns the py.Object
+func (lt *LexToken) Value() py.Object {
+	return lt.value
+}
+
+// Pos returns the ast.Pos
+func (lt *LexToken) Pos() ast.Pos {
+	return lt.pos
+}
+
 // An slice of LexToken~s
 type LexTokens []LexToken
 


### PR DESCRIPTION
It's useful to be able to get at the token, value and pos on lextoken when writing a parser that only relies on the lex functionality of this library.